### PR TITLE
fix: Update gap analysis tests and fix monitoring method name

### DIFF
--- a/src/services/gap_analysis.py
+++ b/src/services/gap_analysis.py
@@ -388,7 +388,7 @@ class GapAnalysisService(TokenTrackingMixin):
                 self.logger.error(f"[GAP_ANALYSIS_EMPTY_DEBUG] {repr(raw_response_before_clean)}")
                 
                 # Log to monitoring service
-                monitoring_service.track_custom_event(
+                monitoring_service.track_event(
                     "GapAnalysisEmptyFields",
                     {
                         "empty_fields": ",".join(empty_fields),

--- a/tests/unit/test_gap_analysis.py
+++ b/tests/unit/test_gap_analysis.py
@@ -189,7 +189,7 @@ class TestParseGapResponse:
         assert len(result["strengths"]) == 1
         assert len(result["gaps"]) == 1
         assert len(result["improvements"]) == 0
-        assert result["assessment"] == ""
+        assert result["assessment"] == "Overall assessment not available. Please refer to the detailed analysis above."
         assert len(result["skill_queries"]) == 0
     
     def test_parse_empty_response(self):
@@ -199,7 +199,7 @@ class TestParseGapResponse:
         assert result["strengths"] == []
         assert result["gaps"] == []
         assert result["improvements"] == []
-        assert result["assessment"] == ""
+        assert result["assessment"] == "Overall assessment not available. Please refer to the detailed analysis above."
         assert result["skill_queries"] == []
 
 
@@ -252,10 +252,10 @@ class TestFormatGapAnalysisHtml:
         
         result = format_gap_analysis_html(parsed_response)
         
-        assert result["CoreStrengths"] == "<ol></ol>"
-        assert result["KeyGaps"] == "<ol></ol>"
-        assert result["QuickImprovements"] == "<ol></ol>"
-        assert result["OverallAssessment"] == "<p></p>"
+        assert result["CoreStrengths"] == "<ol><li>Unable to analyze core strengths. Please try again.</li></ol>"
+        assert result["KeyGaps"] == "<ol><li>Unable to analyze key gaps. Please try again.</li></ol>"
+        assert result["QuickImprovements"] == "<ol><li>Unable to analyze quick improvements. Please try again.</li></ol>"
+        assert result["OverallAssessment"] == "<p>Unable to generate a comprehensive assessment. Please review the individual sections above for detailed analysis.</p>"
         assert result["SkillSearchQueries"] == []
 
 


### PR DESCRIPTION
## Summary
- Fixed monitoring service method call from `track_custom_event` to `track_event`
- Updated unit tests to expect default messages instead of empty strings

## Problem
After the previous PR (#7), the gap analysis unit tests were failing because:
1. The monitoring service doesn't have a `track_custom_event` method (it's `track_event`)
2. Tests expected empty strings but now we return user-friendly default messages

## Solution
1. Fixed the method name in `gap_analysis.py`
2. Updated test expectations to match the new behavior with default messages

## Test Results
All tests now pass:
- ✅ 16/16 gap analysis unit tests passing
- ✅ All pre-commit tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)