### PR TITLE
Fix: Production deployment ruff command for virtual environment

### DIFF
--- a/precommit.sh
+++ b/precommit.sh
@@ -184,7 +184,7 @@ if [ $TEST_LEVEL -ge 1 ] && [ "$SKIP_LOWER_LEVELS" = false ]; then
                      "tests:tests/unit/test_keyword*.py tests/integration/test_api_endpoints.py"; do
         name="${component%%:*}"
         files="${component#*:}"
-        if ruff check $files --exclude=legacy,archive >/dev/null 2>&1; then
+        if python -m ruff check $files --exclude=legacy,archive >/dev/null 2>&1; then
             ((components_passed++))
         fi
     done


### PR DESCRIPTION
## Problem
Production deployments are failing at Level 1 code style checks because 'ruff check' command is not found in the GitHub Actions virtual environment.

## Solution
Changed from `ruff check` to `python -m ruff check` to ensure ruff is executed within the correct Python virtual environment.

## Testing
- Staging deployments already have this fix and are passing
- This change ensures production deployments will also pass

## Related
- Fixes production deployment failures seen in: https://github.com/YuWenHao1212/azure_fastapi/actions/runs/16561207750/job/46831158643